### PR TITLE
Fix repository error

### DIFF
--- a/conf/kodi.list
+++ b/conf/kodi.list
@@ -1,4 +1,0 @@
-# kodi repos
-# starting with debian jessie, debian provides kodi via its backports repository
-# remember: those packages are not supported by team kodi
-deb http://http.debian.net/debian jessie-backports main

--- a/scripts/install
+++ b/scripts/install
@@ -78,7 +78,6 @@ fi
 # INSTALL DEPENDENCIES AND KODI
 #=================================================
 if [[ $arch != arm*  ]]; then
-    sudo cp ../conf/kodi.list "/etc/apt/sources.list.d/${app}.list"
     ynh_package_update
     ynh_package_install xorg xinit dbus-x11 kodi
 else

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -79,7 +79,6 @@ ynh_add_systemd_config
 # INSTALL DEPENDENCIES AND KODI
 #=================================================
 if [[ "$arch" != arm*  ]]; then
-    sudo cp ../conf/kodi.list "/etc/apt/sources.list.d/${app}.list"
     ynh_package_update
     ynh_package_install xorg xinit dbus-x11 kodi
 else


### PR DESCRIPTION
W: The repository 'http://http.debian.net/debian jessie-backports Release' does not have a Release file.